### PR TITLE
Changed return type to catch more data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This .NET Standard 2.0 API allows programmatic control over the basic functions 
 * [Zentec Living Smart Plug Outlet with USB Port](https://www.amazon.com/gp/product/B074YGV2NK)
 * [ISELECTOR Mini Smart Plug](https://www.amazon.com/gp/product/B075XL3DRD)
 * [Xenon Smart Plug PW701U](https://www.amazon.com/Xenon-PW701U-Socket-Outlet-Android/dp/B06W55BTV5)
+* [Teckin Smart Plug SH-SP23-2-UK](https://www.amazon.co.uk/gp/product/B07CVJYV3G)
 
 Many Smart Plug devices compatible with the Tuya Smart Life and Jinvoo Smart app also appear to be compatible with the Tuya protocol.
 

--- a/m4rcus.TuyaCore/TuyaPlug.cs
+++ b/m4rcus.TuyaCore/TuyaPlug.cs
@@ -1,15 +1,26 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+
 using System;
+using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace m4rcus.TuyaCore
 {
+    public struct TuyaStatus
+    {
+        public bool Powered;
+        public int Delay;
+        public double Current_mA;
+        public double Power_W;
+        public double Voltage_V;
+    }
+    
+
     public class TuyaPlug : TuyaDevice
     {
-        public async Task<(bool Powered, int Delay)> GetStatus()
+        public async Task<TuyaStatus> GetStatus()
         {
             var cmd = new Dictionary<string, object>
             {
@@ -22,8 +33,23 @@ namespace m4rcus.TuyaCore
             json = ReadBuffer(await Send(buffer));
             try
             {
-                dynamic result = JObject.Parse(json);
-                return (result.dps["1"], result.dps["2"]);
+                TuyaStatus tuyaStatus = new TuyaStatus();
+
+                JObject result = JObject.Parse(json);
+                if (result["dps"] != null)
+                {
+                    if (result["dps"]["1"] != null)
+                        tuyaStatus.Powered = (bool)result["dps"]["1"].ToObject(typeof(bool));
+                    if (result["dps"]["2"] != null)
+                        tuyaStatus.Delay = (int)result["dps"]["2"].ToObject(typeof(int));
+                    if (result["dps"]["4"] != null)
+                        tuyaStatus.Current_mA = (double)result["dps"]["4"].ToObject(typeof(double));                    
+                    if (result["dps"]["5"] != null)
+                        tuyaStatus.Power_W = (double)result["dps"]["5"].ToObject(typeof(double));
+                    if (result["dps"]["6"] != null)
+                        tuyaStatus.Voltage_V = (double)result["dps"]["6"].ToObject(typeof(double));
+                }
+                return (tuyaStatus);
             }
             catch (Exception ex)
             {

--- a/m4rcus.TuyaCore/TuyaPlug.cs
+++ b/m4rcus.TuyaCore/TuyaPlug.cs
@@ -47,7 +47,7 @@ namespace m4rcus.TuyaCore
                     if (result["dps"]["5"] != null)
                         tuyaStatus.Power_W = (double)result["dps"]["5"].ToObject(typeof(double));
                     if (result["dps"]["6"] != null)
-                        tuyaStatus.Voltage_V = (double)result["dps"]["6"].ToObject(typeof(double));
+                        tuyaStatus.Voltage_V = (double)result["dps"]["6"].ToObject(typeof(double))/10.0;
                 }
                 return (tuyaStatus);
             }


### PR DESCRIPTION

I found with my plug that the JSON contained a bit more information,…  …
… hence I changed the return type to reflect this,

               // what my plug returned. - TECKIN Smart Plug WiFi.
               // {"devId":"56162643807d3a15925d","dps":{"1":true,"2":0,"4":56,"5":74,"6":2369}}

                // 1. state of the plug
                // 2. Delay
                // 4. Current (mA)
                // 5. Power (W)
                // 6. Voltage ( x 10) (V)   so 2369 -> 236.9 V